### PR TITLE
Skip cart flyout elements in product processing

### DIFF
--- a/userscript/soldby.user.js
+++ b/userscript/soldby.user.js
@@ -206,6 +206,9 @@
 
       products.forEach((product) => {
 
+        // Skip elements in the cart flyout
+        if (product.closest('#ewc-content, #nav-flyout-ewc, #nav-cart, #nav-cart-flyout')) return;
+        
         // Give each product the data-seller-name attribute to prevent re-capturing.
         product.dataset.sellerName = 'loading...';
 


### PR DESCRIPTION
Added a check to skip elements in the cart flyout.

Fixes a enlarged cart item which prevents to remove items for example.
Befure: <img width="176" height="557" alt="grafik" src="https://github.com/user-attachments/assets/bfd0529b-e1df-4b9a-85b4-0841538ace62" /> After: <img width="137" height="443" alt="grafik" src="https://github.com/user-attachments/assets/9cf6a205-78fb-42a5-bea6-cbd6d03f3de0" />

PS: after testing my fix, the delete button was visible again, before it was completely hidden and the pictures even bigger scaled.